### PR TITLE
Check item size on updateItem.

### DIFF
--- a/actions/updateItem.js
+++ b/actions/updateItem.js
@@ -77,6 +77,9 @@ module.exports = function updateItem(store, data, cb) {
           }
         }
 
+        if (db.itemSize(item) > 65536)
+            return cb(db.validationError('Item size has exceeded the maximum allowed size'))
+
         if (data.ReturnValues == 'ALL_NEW') {
           returnObj.Attributes = item
         } else if (data.ReturnValues == 'UPDATED_NEW') {

--- a/test/updateItem.js
+++ b/test/updateItem.js
@@ -437,6 +437,14 @@ describe('updateItem', function() {
         'Cannot update attribute a. This attribute is part of the key', done)
     })
 
+    it('should return ValidationException update item is too big', function(done) {
+      var key = {a: {S: helpers.randomString()}},
+        updates = { b: {Action: 'PUT', Value: {S: new Array(65536).join('a')}},
+        c: {Action: 'PUT', Value: {N: new Array(38 + 1).join('1') + new Array(89).join('0')}}}
+      assertValidation({TableName: helpers.testHashTable, Key: key, AttributeUpdates: updates},
+        'Item size has exceeded the maximum allowed size', done)
+    })
+
     it('should return ValidationException if trying to delete NS from SS', function(done) {
       var key = {a: {S: helpers.randomString()}}
       var updates = {b: {Value: {SS: ['1']}}}


### PR DESCRIPTION
Right now dynalite only checks for item size on putItem, it should also check for it on updateItem.  
