### PR TITLE
Skip over authorization headers that aren't strings.

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,6 +124,7 @@ function httpHandler(store, req, res) {
       // "'Credential' not a valid key=value pair (missing equal-sign) in Authorization header: 'AWS4-HMAC-SHA256 \
       // Signature=b,    Credential,    SignedHeaders'."
       for (var i in headers) {
+        if (typeof headers[i] === 'function') continue;
         if (!authParams[headers[i]])
           // TODO: SignedHeaders *is* allowed to be an empty string at this point
           msg += 'Authorization header requires \'' + headers[i] + '\' parameter. '


### PR DESCRIPTION
This fixes a bug where JavaScript extensions, in particular functions,
to the base Object type may be enumerated over and used as a header field.
