### PR TITLE
Fix query with binary keys, improve limit accuracy for query, some support for query filters, fix native java aws sdk conditional support for updates

### DIFF
--- a/actions/query.js
+++ b/actions/query.js
@@ -135,6 +135,13 @@ module.exports = function query(store, data, cb) {
     } else {
       vals = db.lazy(itemDb.createValueStream(opts), cb)
     }
+	
+	//TODO: This doesn't handle reporting counts correctly
+	if(data.QueryFilter) {
+		vals = vals.filter(function(val) {
+		  return db.matchesFilter(val, data.QueryFilter);
+		})
+	}
 
     vals = vals.filter(function(val) {
       if (!db.matchesFilter(val, data.KeyConditions)) {

--- a/db/index.js
+++ b/db/index.js
@@ -295,7 +295,7 @@ function itemCompare(rangeKey, table) {
 function checkConditional(data, existingItem) {
   var expected = data.Expected
   if (!expected) return
-
+  
   existingItem = existingItem || {}
 
   if (!matchesFilter(existingItem, expected, data.ConditionalOperator)) {
@@ -395,6 +395,12 @@ function matchesFilter(val, filter, conditionalOperator) {
       if (filter[attr].Exists === false && attrVal != null) return false
       if (filter[attr].Value && !valueEquals(filter[attr].Value, val[attr])) return false
       return true
+    }
+	
+	//support non-attribute list mechanism used by conditional update expressions
+	if(compVal == null && filter[attr].Value !== undefined) {
+        compType = Object.keys(filter[attr].Value)[0];
+        compVal = filter[attr].Value[compType];
     }
 
     switch (comp) {

--- a/db/index.js
+++ b/db/index.js
@@ -188,7 +188,8 @@ function checkKeySize(keyPiece, type, isHash) {
 //
 function toLexiStr(keyPiece, type) {
   if (keyPiece == null) return ''
-  if (type != 'N') return keyPiece
+  if (type == 'S') return keyPiece
+  if (type == 'B') return new Buffer(keyPiece, "base64").toString("hex");
   var bigNum = Big(keyPiece), digits,
       exp = !bigNum.c[0] ? 0 : bigNum.s == -1 ? 125 - bigNum.e : 130 + bigNum.e
   if (bigNum.s == -1) {
@@ -406,22 +407,26 @@ function matchesFilter(val, filter, conditionalOperator) {
       case 'LE':
         if (compType != attrType ||
           (attrType == 'N' && !Big(attrVal).lte(compVal)) ||
-          (attrType != 'N' && attrVal > compVal)) return false
+          (attrType == 'S' && attrVal > compVal) ||
+		  (attrType == 'B' && new Buffer(attrVal, "base64").toString("hex") > new Buffer(compVal,"base64").toString("hex"))) return false
         break
       case 'LT':
         if (compType != attrType ||
           (attrType == 'N' && !Big(attrVal).lt(compVal)) ||
-          (attrType != 'N' && attrVal >= compVal)) return false
+          (attrType == 'S' && attrVal >= compVal) ||
+		  (attrType == 'B' && new Buffer(attrVal, "base64").toString("hex") >= new Buffer(compVal,"base64").toString("hex"))) return false
         break
       case 'GE':
         if (compType != attrType ||
           (attrType == 'N' && !Big(attrVal).gte(compVal)) ||
-          (attrType != 'N' && attrVal < compVal)) return false
+          (attrType == 'S' && attrVal < compVal) ||
+		  (attrType == 'B' && new Buffer(attrVal, "base64").toString("hex") < new Buffer(compVal,"base64").toString("hex"))) return false
         break
       case 'GT':
         if (compType != attrType ||
           (attrType == 'N' && !Big(attrVal).gt(compVal)) ||
-          (attrType != 'N' && attrVal <= compVal)) return false
+          (attrType == 'S' && attrVal <= compVal) ||
+		  (attrType == 'B' && new Buffer(attrVal, "base64").toString("hex") <= new Buffer(compVal,"base64").toString("hex"))) return false
         break
       case 'NOT_NULL':
         if (!attrVal) return false

--- a/validations/query.js
+++ b/validations/query.js
@@ -93,6 +93,42 @@ exports.types = {
     lengthLessThanOrEqual: 255,
   },
   ScanIndexForward: 'Boolean',
+  QueryFilter: {
+    type: 'Map',
+    children: {
+      type: 'Structure',
+      children: {
+        AttributeValueList: {
+          type: 'List',
+          children: {
+            type: 'Structure',
+            children: {
+              S: 'String',
+              B: 'Blob',
+              N: 'String',
+              BS: {
+                type: 'List',
+                children: 'Blob',
+              },
+              NS: {
+                type: 'List',
+                children: 'String',
+              },
+              SS: {
+                type: 'List',
+                children: 'String',
+              }
+            }
+          }
+        },
+        ComparisonOperator: {
+          type: 'String',
+          notNull: true,
+          enum: ['IN', 'NULL', 'BETWEEN', 'LT', 'NOT_CONTAINS', 'EQ', 'GT', 'NOT_NULL', 'NE', 'LE', 'BEGINS_WITH', 'GE', 'CONTAINS']
+        }
+      }
+    }
+  },
 }
 
 exports.custom = function(data) {


### PR DESCRIPTION
This project is cool.  I had to do so many hacks for DynamoDB Local, I figured it would be better to just improve this project to have an alternative.  I used our unit tests to cross check this, dynamo local, and real dynamo.  This led me to find a few issues.

Base64 doesn't have the same ordering as the byte arrays so that made a lot queries return weird results.  I modified the comparison test functions to special case the B type and round trip the buffers to hex strings so they compare naturally.  Comparing as buffers with <, >, <=, etc doesn't work and the Buffer.compare method is not available until Node 0.12.

Updates have a slightly different syntax from SDK docs when you look at them over the wire.  The AttributeValue array is not present, only a Value is in all the cases in my project.  I added a second phase of lookup for the compVal to make sure the correct entries can be loaded.

Query filters were missing and they were added by simply reusing the existing filter function and logic.  This was trivial, but it does not do any faithful modelling of the effect on Count and ScannedCount.

Limit's on queries don't cause the LastEvaluatedKey to be set.  The docs say this and the both variants of Dynamo seem to conform to that as well.  That said, the original reason I was looking for an alternative is because I found local Dynamo sometimes did not return a LastEvaluatedKey even when there were more results.  It's probably an instance of the same Base64 comparison issue but they only use code based logic for a test from the final test to decide whether or not to include the LastEvaluatedKey.  Interestingly real Dynamo appears to not return a LastEvaluatedKey for a request that exactly reads the final set of entries.  It must be peaking ahead to determine this.