### PR TITLE
Traverse maps during validation

### DIFF
--- a/test/putItem.js
+++ b/test/putItem.js
@@ -153,6 +153,11 @@ describe('putItem', function() {
         'One or more parameter values were invalid: An AttributeValue may not contain an empty string', done)
     })
 
+    it('should return ValidationException for empty string in map', function(done) {
+      assertValidation({TableName: 'abc', Item: {a: {M: {b: {S: ''}}}}},
+        'One or more parameter values were invalid: An AttributeValue may not contain an empty string', done)
+    })
+
     it('should return ValidationException for empty binary', function(done) {
       assertValidation({TableName: 'abc', Item: {a: {B: ''}}},
         'One or more parameter values were invalid: An AttributeValue may not contain a null or empty binary type.', done)

--- a/validations/index.js
+++ b/validations/index.js
@@ -380,6 +380,13 @@ function validateAttributeValue(value) {
 
     if (type == 'BS' && hasDuplicates(value[type]))
       return 'One or more parameter values were invalid: Input collection ' + valueStr(value[type]) + 'of type BS contains duplicates.'
+
+    if (type == 'M') {
+        for (var attr in value[type]) {
+            var err = validateAttributeValue(value[type][attr]);
+            if (err) return err;
+        }
+    }
   }
 
   if (types.length > 1)


### PR DESCRIPTION
We ran into an issue where dynalite is too relaxed around empty strings inside maps. I added a test case for this and made an attempt to add recursive validation for maps.