### PR TITLE
Add a todo item pointing to the list of open issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ TODO
 - Implement `ReturnItemCollectionMetrics` on all remaining endpoints
 - Implement size info for tables and indexes
 - Is the `ListTables` limit of names returned 100 if no `Limit` supplied?
+- See [open issues](https://github.com/mhart/dynalite/issues) for an up to date list of outstanding features
 
 Problems with Amazon's DynamoDB Local
 -------------------------------------


### PR DESCRIPTION
I expected the TODO list to be complete and didn't realise there's a whole bunch of issues for unsupported features. This links to the list of issues to make it clear that there's more outstanding issues. It might be worth adding a separate label for these type of issues to differentiate them from bug reports/support requests.