### PR TITLE
More lenient check on client side Content-Type header for browser compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ function httpHandler(store, req, res) {
     var contentType = req.headers['content-type']
 
     if (req.method != 'POST' ||
-        (body && contentType != 'application/json' && contentType != 'application/x-amz-json-1.0')) {
+        (body && contentType != 'application/json' && contentType.indexOf('application/x-amz-json-1.0') < 0)) {
       req.removeAllListeners()
       res.statusCode = 404
       res.setHeader('x-amz-crc32', 3552371480)
@@ -266,4 +266,3 @@ function httpHandler(store, req, res) {
 }
 
 if (require.main === module) dynalite().listen(4567)
-


### PR DESCRIPTION
Hello,

While using dynalite on my local development environment, I also wrote a little database browser using client-side Javascript with AWS SDK.

I found that on web browsers (I'm using Firefox), client-side may send `application/x-amz-json-1.0; charset=UTF-8` instead of simply `application/x-amz-json-1.0` in `Content-Type` header, and this would be considered by dynalite as an unknown operation.

So I changed the content type check to simply see if `application/x-amz-json-1.0` exist in `Content-Type` header. With this change I can access dynalite using client side Javascript.

See if this change is appropriate. Thanks.