### PR TITLE
Fix contains condition for lists

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -648,37 +648,9 @@ function compare(comp, val, compVals) {
       break
     case 'CONTAINS':
     case 'contains':
-      if (compType == 'S') {
-        if (attrType != 'S' && attrType != 'SS') return false
-        if (!~attrVal.indexOf(compVal)) return false
-      }
-      if (compType == 'N') {
-        if (attrType != 'NS') return false
-        if (!~attrVal.indexOf(compVal)) return false
-      }
-      if (compType == 'B') {
-        if (attrType != 'B' && attrType != 'BS') return false
-        if (attrType == 'B') {
-          attrVal = new Buffer(attrVal, 'base64').toString()
-          compVal = new Buffer(compVal, 'base64').toString()
-        }
-        if (!~attrVal.indexOf(compVal)) return false
-      }
-      break
+      return doContainsComparison(compType, compVal, attrType, attrVal)
     case 'NOT_CONTAINS':
-      if (compType == 'S' && (attrType == 'S' || attrType == 'SS') &&
-          ~attrVal.indexOf(compVal)) return false
-      if (compType == 'N' && attrType == 'NS' &&
-          ~attrVal.indexOf(compVal)) return false
-      if (compType == 'B') {
-        if (attrType == 'B') {
-          attrVal = new Buffer(attrVal, 'base64').toString()
-          compVal = new Buffer(compVal, 'base64').toString()
-        }
-        if ((attrType == 'B' || attrType == 'BS') &&
-            ~attrVal.indexOf(compVal)) return false
-      }
-      break
+      return !doContainsComparison(compType, compVal, attrType, attrVal)
     case 'BEGINS_WITH':
     case 'begins_with':
       if (compType != attrType) return false
@@ -708,6 +680,41 @@ function compare(comp, val, compVals) {
       if (!attrVal || !valsEqual(attrType, compVal)) return false
   }
   return true
+}
+
+function doContainsComparison(compType, compVal, attrType, attrVal) {
+  if (compType === 'S') {
+    if (attrType === 'S') return !!~attrVal.indexOf(compVal)
+    if (attrType === 'SS') return attrVal.some(function(val) {
+      return val === compVal
+    })
+    if (attrType === 'L') return attrVal.some(function(val) {
+      return val && val.S && val.S === compVal
+    })
+    return false
+  }
+  if (compType === 'N') {
+    if (attrType === 'NS') return attrVal.some(function(val) {
+      return val === compVal
+    })
+    if (attrType === 'L') return attrVal.some(function(val) {
+      return val && val.N && val.N === compVal
+    })
+    return false
+  }
+  if (compType === 'B') {
+    if (attrType !== 'B' && attrType !== 'BS' && attrType !== 'L') return false
+    var compValString = new Buffer(compVal, 'base64').toString()
+    if (attrType === 'B') {
+      var attrValString = new Buffer(attrVal, 'base64').toString()
+      return !!~attrValString.indexOf(compValString)
+    }
+    return attrVal.some(function(val) {
+      if (attrType !== 'L') return compValString === new Buffer(val, 'base64').toString()
+      if (attrType === 'L' && val.B) return compValString === new Buffer(val.B, 'base64').toString()
+      return false
+    })
+  }
 }
 
 function mapPaths(paths, item) {

--- a/test/scan.js
+++ b/test/scan.js
@@ -2223,6 +2223,9 @@ describe('scan', function() {
           item4 = {a: {S: helpers.randomString()}, b: {BS: ['abcd', new Buffer('bde').toString('base64')]}, c: item.c},
           item5 = {a: {S: helpers.randomString()}, b: {S: 'bde'}, c: item.c},
           item6 = {a: {S: helpers.randomString()}, b: {S: 'abd'}, c: item.c},
+          item7 = {a: {S: helpers.randomString()}, b: {L: [{'N': '123'}, {'S': 'bde'}]}, c: item.c},
+          item8 = {a: {S: helpers.randomString()}, b: {L: [{'S': 'abd'}]}, c: item.c},
+          item9 = {a: {S: helpers.randomString()}, b: {L: [{'S': 'abde'}]}, c: item.c},
           batchReq = {RequestItems: {}}
       batchReq.RequestItems[helpers.testHashTable] = [
         {PutRequest: {Item: item}},
@@ -2231,6 +2234,9 @@ describe('scan', function() {
         {PutRequest: {Item: item4}},
         {PutRequest: {Item: item5}},
         {PutRequest: {Item: item6}},
+        {PutRequest: {Item: item7}},
+        {PutRequest: {Item: item8}},
+        {PutRequest: {Item: item9}},
       ]
       request(helpers.opts('BatchWriteItem', batchReq), function(err, res) {
         if (err) return done(err)
@@ -2251,8 +2257,9 @@ describe('scan', function() {
             res.body.Items.should.containEql(item)
             res.body.Items.should.containEql(item2)
             res.body.Items.should.containEql(item5)
-            res.body.Items.should.have.length(3)
-            res.body.Count.should.equal(3)
+            res.body.Items.should.containEql(item7)
+            res.body.Items.should.have.length(4)
+            res.body.Count.should.equal(4)
             cb()
           })
         }, done)
@@ -2265,6 +2272,9 @@ describe('scan', function() {
           item3 = {a: {S: helpers.randomString()}, b: {B: new Buffer('1234').toString('base64')}, c: item.c},
           item4 = {a: {S: helpers.randomString()}, b: {BS: [new Buffer('234').toString('base64')]}, c: item.c},
           item5 = {a: {S: helpers.randomString()}, b: {SS: ['234']}, c: item.c},
+          item6 = {a: {S: helpers.randomString()}, b: {L: [{'S': 'abd'}, {'N': '234'}]}, c: item.c},
+          item7 = {a: {S: helpers.randomString()}, b: {L: [{'N': '123'}]}, c: item.c},
+          item8 = {a: {S: helpers.randomString()}, b: {L: [{'N': '1234'}]}, c: item.c},
           batchReq = {RequestItems: {}}
       batchReq.RequestItems[helpers.testHashTable] = [
         {PutRequest: {Item: item}},
@@ -2272,6 +2282,9 @@ describe('scan', function() {
         {PutRequest: {Item: item3}},
         {PutRequest: {Item: item4}},
         {PutRequest: {Item: item5}},
+        {PutRequest: {Item: item6}},
+        {PutRequest: {Item: item7}},
+        {PutRequest: {Item: item8}},
       ]
       request(helpers.opts('BatchWriteItem', batchReq), function(err, res) {
         if (err) return done(err)
@@ -2289,9 +2302,10 @@ describe('scan', function() {
           request(opts(scanOpts), function(err, res) {
             if (err) return cb(err)
             res.statusCode.should.equal(200)
-            res.body.Items.should.have.lengthOf(1)
-            res.body.Items[0].a.should.eql(item2.a)
-            res.body.Count.should.equal(1)
+            res.body.Items.should.containEql(item2)
+            res.body.Items.should.containEql(item6)
+            res.body.Items.should.have.lengthOf(2)
+            res.body.Count.should.equal(2)
             cb()
           })
         }, done)
@@ -2305,6 +2319,9 @@ describe('scan', function() {
           item4 = {a: {S: helpers.randomString()}, b: {BS: [new Buffer('bde').toString('base64'), 'abcd']}, c: item.c},
           item5 = {a: {S: helpers.randomString()}, b: {B: new Buffer('bde').toString('base64')}, c: item.c},
           item6 = {a: {S: helpers.randomString()}, b: {S: 'abd'}, c: item.c},
+          item7 = {a: {S: helpers.randomString()}, b: {L: [{'N': '123'}, {'B': new Buffer('bde').toString('base64')}]}, c: item.c},
+          item8 = {a: {S: helpers.randomString()}, b: {L: [{'B': new Buffer('abd').toString('base64')}]}, c: item.c},
+          item9 = {a: {S: helpers.randomString()}, b: {L: [{'B': new Buffer('abde').toString('base64')}]}, c: item.c},
           batchReq = {RequestItems: {}}
       batchReq.RequestItems[helpers.testHashTable] = [
         {PutRequest: {Item: item}},
@@ -2313,6 +2330,9 @@ describe('scan', function() {
         {PutRequest: {Item: item4}},
         {PutRequest: {Item: item5}},
         {PutRequest: {Item: item6}},
+        {PutRequest: {Item: item7}},
+        {PutRequest: {Item: item8}},
+        {PutRequest: {Item: item9}},
       ]
       request(helpers.opts('BatchWriteItem', batchReq), function(err, res) {
         if (err) return done(err)
@@ -2333,8 +2353,9 @@ describe('scan', function() {
             res.body.Items.should.containEql(item3)
             res.body.Items.should.containEql(item4)
             res.body.Items.should.containEql(item5)
-            res.body.Items.should.have.length(3)
-            res.body.Count.should.equal(3)
+            res.body.Items.should.containEql(item7)
+            res.body.Items.should.have.length(4)
+            res.body.Count.should.equal(4)
             cb()
           })
         }, done)


### PR DESCRIPTION
On "L" types in a dynamoDB you should be able to run a `contains`
condition on that type but it was implicitly excluded in the code for
dynalite. This fixes that issue for both `contains` and `not_contains`.