### PR TITLE
Issue #86:  Limited Filtered Scan can fail to return a LastEvaluatedKey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 coverage*
 .tern-port
 v8.log
+.idea

--- a/db/index.js
+++ b/db/index.js
@@ -837,6 +837,11 @@ function queryTable(store, table, data, opts, isLocal, fetchFromItemDb, startKey
 
   var queryFilter = data.QueryFilter || data.ScanFilter
 
+  var preFilteredItems = []
+  vals.join(function(items) {
+    preFilteredItems = items
+  })
+
   if (data._filter) {
     vals = vals.filter(function(val) { return matchesExprFilter(val, data._filter.expression) })
   } else if (queryFilter) {
@@ -852,9 +857,10 @@ function queryTable(store, table, data, opts, isLocal, fetchFromItemDb, startKey
     var result = {ScannedCount: count}
     if (count >= data.Limit || size >= 1024 * 1024) {
       if (data.Limit) items.splice(data.Limit)
-      if (items.length) {
+      if (preFilteredItems.length) {
         result.LastEvaluatedKey = startKeyNames.reduce(function(key, attr) {
-          key[attr] = items[items.length - 1][attr]
+          key[attr] = preFilteredItems[preFilteredItems.length - 1][attr]
+
           return key
         }, {})
       }

--- a/test/scan.js
+++ b/test/scan.js
@@ -3038,6 +3038,42 @@ describe('scan', function() {
       })
     })
 
+    it('should return LastEvaluatedKey while filtering, even if Limit is smaller than the expected return list', function(done) {
+      var i, b = {S: helpers.randomString()}, items = [], batchReq = {RequestItems: {}}
+
+      // This bug manifests itself when the sought after item is not among the first .Limit number of
+      // items in the scan.  Because we can't guarantee the order of the returned scan items, we can't
+      // guarantee that this test case will produce the bug.  Therefore, we will try to make it very
+      // likely that this bug will be reproduced by adding as many items as we can.  The chances that
+      // the sought after item (to be picked up by the filter) will be among the first .Limit number
+      // of items should be small enough to give us practical assurance of correctness in this one
+      // regard...
+      for (i = 0; i < 25; i++)
+        items.push({a: {S: 'item' + i}})
+      batchReq.RequestItems[helpers.testHashTable] = items.map(function(item) { return {PutRequest: {Item: item}} })
+
+      request(helpers.opts('BatchWriteItem', batchReq), function(err, res) {
+        if (err) return done(err)
+        res.statusCode.should.equal(200)
+
+        request(opts({
+          TableName: helpers.testHashTable,
+          ExpressionAttributeNames: { '#key': 'a' },
+          ExpressionAttributeValues: { ':value': {S: 'item12'} },
+          FilterExpression: '#key = :value',
+          Limit: 2
+        }), function(err, res) {
+          if (err) return done(err)
+
+          res.statusCode.should.equal(200)
+          res.body.ScannedCount.should.equal(2)
+          res.body.LastEvaluatedKey.a.S.should.not.be.empty // eslint-disable-line no-unused-expressions
+          Object.keys(res.body.LastEvaluatedKey).should.have.length(1)
+          done()
+        })
+      })
+    })
+
     it('should not return LastEvaluatedKey if Limit is large', function(done) {
       var i, b = {S: helpers.randomString()}, items = [], batchReq = {RequestItems: {}},
           scanFilter = {b: {ComparisonOperator: 'EQ', AttributeValueList: [b]}}


### PR DESCRIPTION
I believe Issue #86 describes the bug that this PR fixes.

If a table where a scan with a filter were to return an item, adding a limit to
the scan request that is small enough to not return the filtered item will also
fail to return the LastEvaluatedKey, necessary to continue the search...