### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+/.*
+/test
+/LICENSE
+/README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:lts-alpine
+
+ENTRYPOINT ["/usr/local/bin/dynalite"]
+EXPOSE 4567
+RUN adduser -h /var/lib/dynamodb -D -u 4567 dynalite
+
+COPY . /usr/local/share/dynalite
+
+RUN apk add --no-cache --virtual .gyp \
+        python \
+        make \
+        g++ \
+    && npm --unsafe-perm install \
+        -g /usr/local/share/dynalite \
+    && npm --force cache clear \
+    && apk del .gyp \
+    && rm -rf /tmp/* /var/tmp/* /var/cache/*
+
+USER dynalite


### PR DESCRIPTION
Add a `Dockerfile` for using dynalite w/o nodejs.

Unlike #64, this builds from source allowing integration with [docker hub](https://hub.docker.com) by using [automated builds](https://docs.docker.com/docker-hub/builds/).
This would result in having docker hub building and hosting a docker images for each tag and the current latest master/HEAD on each push.

Running dynalite in docker would look like this:

```
docker run --rm -p 4567:4567 dynalite
```

Like the real dynalite executable parameters are available:

```
docker run --rm -p 8123:8123 dynalite --port 8123
```