### PR TITLE
Add TTL support

### DIFF
--- a/actions/describeTimeToLive.js
+++ b/actions/describeTimeToLive.js
@@ -5,7 +5,8 @@ module.exports = function describeTimeToLive (store, data, cb) {
 
     if (table.TimeToLiveDescription !== null && typeof table.TimeToLiveDescription === 'object') {
       cb(null, { TimeToLiveDescription: table.TimeToLiveDescription })
-    } else {
+    }
+    else {
       cb(null, { TimeToLiveDescription: { TimeToLiveStatus: 'DISABLED' } })
     }
   })

--- a/actions/describeTimeToLive.js
+++ b/actions/describeTimeToLive.js
@@ -1,8 +1,12 @@
 
 module.exports = function describeTimeToLive (store, data, cb) {
-  store.getTable(data.TableName, false, function (err) {
+  store.getTable(data.TableName, false, function (err, table) {
     if (err) return cb(err)
 
-    cb(null, { TimeToLiveDescription: { TimeToLiveStatus: 'DISABLED' } })
+    if (table.TimeToLiveDescription !== null && typeof table.TimeToLiveDescription === 'object') {
+      cb(null, { TimeToLiveDescription: table.TimeToLiveDescription })
+    } else {
+      cb(null, { TimeToLiveDescription: { TimeToLiveStatus: 'DISABLED' } })
+    }
   })
 }

--- a/actions/updateTimeToLive.js
+++ b/actions/updateTimeToLive.js
@@ -1,0 +1,38 @@
+var db = require('../db');
+
+module.exports = function updateTimeToLive(store, data, cb) {
+    var key = data.TableName,
+     TimeToLiveSpecification = data.TimeToLiveSpecification,
+     tableDb = store.tableDb,
+        returnValue;
+
+    store.getTable(key, false, function(err, table) {
+        if (err) return cb(err)
+
+        if (TimeToLiveSpecification.Enabled) {
+            if (table.TimeToLiveDescription && table.TimeToLiveDescription.TimeToLiveStatus === 'ENABLED') {
+                return cb(db.validationError('TimeToLive is already enabled'))
+            }
+            table.TimeToLiveDescription = {
+                AttributeName: TimeToLiveSpecification.AttributeName,
+                TimeToLiveStatus: 'ENABLED',
+            }
+            returnValue = TimeToLiveSpecification
+        } else {
+            if (table.TimeToLiveDescription == null || table.TimeToLiveDescription.TimeToLiveStatus === 'DISABLED') {
+                return cb(db.validationError('TimeToLive is already disabled'))
+            }
+
+            table.TimeToLiveDescription = {
+                TimeToLiveStatus: 'DISABLED',
+            }
+            returnValue = {Enabled: false}
+        }
+
+        tableDb.put(key, table, function(err) {
+            if (err) return cb(err)
+
+            cb(null, {TimeToLiveSpecification: returnValue})
+        })
+    })
+}

--- a/actions/updateTimeToLive.js
+++ b/actions/updateTimeToLive.js
@@ -1,38 +1,39 @@
-var db = require('../db');
+var db = require('../db')
 
-module.exports = function updateTimeToLive(store, data, cb) {
-    var key = data.TableName,
-     TimeToLiveSpecification = data.TimeToLiveSpecification,
-     tableDb = store.tableDb,
-        returnValue;
+module.exports = function updateTimeToLive (store, data, cb) {
+  var key = data.TableName,
+    TimeToLiveSpecification = data.TimeToLiveSpecification,
+    tableDb = store.tableDb,
+    returnValue
 
-    store.getTable(key, false, function(err, table) {
-        if (err) return cb(err)
+  store.getTable(key, false, function (err, table) {
+    if (err) return cb(err)
 
-        if (TimeToLiveSpecification.Enabled) {
-            if (table.TimeToLiveDescription && table.TimeToLiveDescription.TimeToLiveStatus === 'ENABLED') {
-                return cb(db.validationError('TimeToLive is already enabled'))
-            }
-            table.TimeToLiveDescription = {
-                AttributeName: TimeToLiveSpecification.AttributeName,
-                TimeToLiveStatus: 'ENABLED',
-            }
-            returnValue = TimeToLiveSpecification
-        } else {
-            if (table.TimeToLiveDescription == null || table.TimeToLiveDescription.TimeToLiveStatus === 'DISABLED') {
-                return cb(db.validationError('TimeToLive is already disabled'))
-            }
+    if (TimeToLiveSpecification.Enabled) {
+      if (table.TimeToLiveDescription && table.TimeToLiveDescription.TimeToLiveStatus === 'ENABLED') {
+        return cb(db.validationError('TimeToLive is already enabled'))
+      }
+      table.TimeToLiveDescription = {
+        AttributeName: TimeToLiveSpecification.AttributeName,
+        TimeToLiveStatus: 'ENABLED',
+      }
+      returnValue = TimeToLiveSpecification
+    }
+    else {
+      if (table.TimeToLiveDescription == null || table.TimeToLiveDescription.TimeToLiveStatus === 'DISABLED') {
+        return cb(db.validationError('TimeToLive is already disabled'))
+      }
 
-            table.TimeToLiveDescription = {
-                TimeToLiveStatus: 'DISABLED',
-            }
-            returnValue = {Enabled: false}
-        }
+      table.TimeToLiveDescription = {
+        TimeToLiveStatus: 'DISABLED',
+      }
+      returnValue = { Enabled: false }
+    }
 
-        tableDb.put(key, table, function(err) {
-            if (err) return cb(err)
+    tableDb.put(key, table, function (err) {
+      if (err) return cb(err)
 
-            cb(null, {TimeToLiveSpecification: returnValue})
-        })
+      cb(null, { TimeToLiveSpecification: returnValue })
     })
+  })
 }

--- a/cli.js
+++ b/cli.js
@@ -20,6 +20,8 @@ if (argv.help || argv.h) {
     '--deleteTableMs <ms>  Amount of time tables stay in DELETING state (default: 500)',
     '--updateTableMs <ms>  Amount of time tables stay in UPDATING state (default: 500)',
     '--maxItemSizeKb <kb>  Maximum item size (default: 400)',
+    '--ttlCheckEvery <s>   Time gap between TTL expiration background job (default: 60)' +
+    '                      0 or negative disable TTL expiration',
     '--verbose, -v         Enable verbose logging',
     '--debug, -d           Enable debug logging',
     '',

--- a/db/index.js
+++ b/db/index.js
@@ -38,6 +38,7 @@ exports.mapPath = mapPath
 exports.queryTable = queryTable
 exports.updateIndexes = updateIndexes
 exports.getIndexActions = getIndexActions
+exports.deleteItem = deleteItem
 
 function create (options) {
   options = options || {}
@@ -140,15 +141,30 @@ function create (options) {
               if (err) return
               if (!table.TimeToLiveDescription || table.TimeToLiveDescription.TimeToLiveStatus !== 'ENABLED') return
 
+              var keyAttrNames = table.KeySchema.map(function(i) {
+                return i.AttributeName
+              })
+              var source = {
+                getItemDb: getItemDb,
+                getIndexDb: getIndexDb,
+              }
               var itemDb = getItemDb(table.TableName)
               var kvStream = lazyStream(itemDb.createReadStream({}), logError())
               kvStream = kvStream.filter(function(item){
                 var ttl = item.value[table.TimeToLiveDescription.AttributeName]
                 return ttl && typeof ttl.N === 'string' && currentUnixSeconds > Number(ttl.N)
               })
-              kvStream.join(function(items){
-                items.forEach(function(item) {
-                  itemDb.del(item.key)
+              kvStream.join(function(kvs){
+                kvs.forEach(function(kv) {
+                  var itemKey = keyAttrNames.reduce(function(key, attrName) {
+                    key[attrName] = kv.value[attrName]
+                    return key
+                  }, {})
+                  var data = { TableName: name, Key: itemKey}
+                  var cb = function(err) {
+                    // Noop ?
+                  }
+                  deleteItem(source, data, table, itemDb, kv.key, cb)
                 })
               })
             })
@@ -220,6 +236,35 @@ function validateItem (dataItem, table) {
   })
 }
 
+function deleteItem(store, data, table, itemDb, key, cb) {
+  itemDb.lock(key, function(release) {
+    cb = release(cb)
+
+    itemDb.get(key, function(err, existingItem) {
+      if (err && err.name !== 'NotFoundError') return cb(err)
+
+      if ((err = checkConditional(data, existingItem)) != null) return cb(err)
+
+      var returnObj = {}
+
+      if (existingItem && data.ReturnValues === 'ALL_OLD')
+        returnObj.Attributes = existingItem
+
+      returnObj.ConsumedCapacity = addConsumedCapacity(data, false, existingItem)
+
+      updateIndexes(store, table, existingItem, null, function(err) {
+        if (err) return cb(err)
+
+        itemDb.del(key, function(err) {
+          if (err) return cb(err)
+          cb(null, returnObj)
+        })
+      })
+    })
+  })
+}
+
+function validateUpdates(attributeUpdates, expressionUpdates, table) {
 function validateUpdates (attributeUpdates, expressionUpdates, table) {
   if (attributeUpdates == null && expressionUpdates == null) return
 

--- a/db/index.js
+++ b/db/index.js
@@ -138,7 +138,7 @@ function create (options) {
       var currentUnixSeconds = Math.round(Date.now() / 1000)
 
       function logError(err, result) {
-        if (err) console.error("@@@", err)
+        if (err) console.error(err)
       }
 
       lazyStream(tableDb.createKeyStream({}), logError)
@@ -156,7 +156,7 @@ function create (options) {
                   getIndexDb: getIndexDb,
                 }
                 var itemDb = getItemDb(table.TableName)
-                var kvStream = lazyStream(itemDb.createReadStream({}), logError())
+                var kvStream = lazyStream(itemDb.createReadStream({}), logError)
                 kvStream = kvStream.filter(function (item) {
                   var ttl = item.value[table.TimeToLiveDescription.AttributeName]
                   return ttl && typeof ttl.N === 'string' && currentUnixSeconds > Number(ttl.N)

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ var debug = false
 var validApis = [ 'DynamoDB_20111205', 'DynamoDB_20120810' ],
   validOperations = [ 'BatchGetItem', 'BatchWriteItem', 'CreateTable', 'DeleteItem', 'DeleteTable',
     'DescribeTable', 'DescribeTimeToLive', 'GetItem', 'ListTables', 'PutItem', 'Query', 'Scan', 'TagResource',
-    'UntagResource', 'ListTagsOfResource', 'UpdateItem', 'UpdateTable' ],
+    'UntagResource', 'ListTagsOfResource', 'UpdateItem', 'UpdateTable', 'UpdateTimeToLive' ],
   actions = {},
   actionValidations = {}
 
@@ -57,6 +57,7 @@ function dynalite (options) {
   // Ensure we close DB when we're closing the server too
   var httpServerClose = server.close, httpServerListen = server.listen
   server.close = function (cb) {
+    store.stopBackgroundJobs()
     store.db.close(function (err) {
       if (err) return cb(err)
       // Recreate the store if the user wants to listen again

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ Options:
 --deleteTableMs <ms>  Amount of time tables stay in DELETING state (default: 500)
 --updateTableMs <ms>  Amount of time tables stay in UPDATING state (default: 500)
 --maxItemSizeKb <kb>  Maximum item size (default: 400)
---ttlCheckEvery <kb>  Time gap between TTL expiration background job (default: 60)
+--ttlCheckEvery <s>   Time gap between TTL expiration background job (default: 60)
                       0 or negative disable TTL expiration
 --verbose, -v         Enable verbose logging
 --debug, -d           Enable debug logging

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,8 @@ Options:
 --deleteTableMs <ms>  Amount of time tables stay in DELETING state (default: 500)
 --updateTableMs <ms>  Amount of time tables stay in UPDATING state (default: 500)
 --maxItemSizeKb <kb>  Maximum item size (default: 400)
+--ttlCheckEvery <kb>  Time gap between TTL expiration background job (default: 60)
+                      0 or negative disable TTL expiration
 --verbose, -v         Enable verbose logging
 --debug, -d           Enable debug logging
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -50,8 +50,12 @@ var port = 10000 + Math.round(Math.random() * 10000),
   requestOpts = useRemoteDynamo ?
     { host: 'dynamodb.' + exports.awsRegion + '.amazonaws.com', method: 'POST' } :
     { host: '127.0.0.1', port: port, method: 'POST' }
+var ttlCheckEvery = 1
 
-var dynaliteServer = dynalite({ path: process.env.DYNALITE_PATH })
+var dynaliteServer = dynalite({
+  path: process.env.DYNALITE_PATH,
+  ttlCheckEvery: ttlCheckEvery,
+})
 
 var CREATE_REMOTE_TABLES = true
 var DELETE_REMOTE_TABLES = true

--- a/test/updateTimeToLive.js
+++ b/test/updateTimeToLive.js
@@ -1,0 +1,198 @@
+var helpers = require('./helpers')
+
+var target = 'UpdateTimeToLive',
+    request = helpers.request,
+    opts = helpers.opts.bind(null, target),
+    assertType = helpers.assertType.bind(null, target),
+    assertValidation = helpers.assertValidation.bind(null, target),
+    assertNotFound = helpers.assertNotFound.bind(null, target)
+
+describe('updateTimeToLive', function() {
+
+  describe('serializations', function() {
+
+    it('should return SerializationException when TableName is not a string', function(done) {
+      assertType('TableName', 'String', done)
+    })
+
+    it('should return SerializationException when TimeToLiveSpecification is not a struct', function(done) {
+      assertType('TimeToLiveSpecification', 'FieldStruct<TimeToLiveSpecification>', done)
+    })
+
+    it('should return SerializationException when TimeToLiveSpecification.AttributeName is not a string', function(done) {
+      assertType('TimeToLiveSpecification.AttributeName', 'String', done)
+    })
+
+    it('should return SerializationException when TimeToLiveSpecification.Enabled is not a boolean', function(done) {
+      assertType('TimeToLiveSpecification.Enabled', 'Boolean', done)
+    })
+
+  })
+
+  describe('validations', function() {
+
+    it('should return ValidationException for no TableName', function(done) {
+      assertValidation({},
+        'The parameter \'TableName\' is required but was not present in the request', done)
+    })
+
+    it('should return ValidationException for empty TableName', function(done) {
+      assertValidation({TableName: ''},
+        'TableName must be at least 3 characters long and at most 255 characters long', done)
+    })
+
+    it('should return ValidationException for short TableName', function(done) {
+      assertValidation({TableName: 'a;'},
+        'TableName must be at least 3 characters long and at most 255 characters long', done)
+    })
+
+    it('should return ValidationException for long TableName', function(done) {
+      var name = new Array(256 + 1).join('a')
+      assertValidation({TableName: name},
+        'TableName must be at least 3 characters long and at most 255 characters long', done)
+    })
+
+    it('should return ValidationException for invalid chars', function(done) {
+      assertValidation({TableName: 'abc;'},
+        '1 validation error detected: ' +
+        'Value \'abc;\' at \'tableName\' failed to satisfy constraint: ' +
+        'Member must satisfy regular expression pattern: [a-zA-Z0-9_.-]+', done)
+    })
+
+    it('should return ValidationException for empty TimeToLiveSpecification', function(done) {
+      assertValidation({TableName: 'abc', TimeToLiveSpecification: {}}, [
+        'Value null at \'timeToLiveSpecification.enabled\' failed to satisfy constraint: ' +
+        'Member must not be null',
+        'Value null at \'timeToLiveSpecification.attributeName\' failed to satisfy constraint: ' +
+        'Member must not be null',
+      ], done)
+    })
+
+    it('should return ValidationException for null members in TimeToLiveSpecification', function(done) {
+      assertValidation({TableName: 'abc', TimeToLiveSpecification: {AttributeName: null, Enabled: null}}, [
+        'Value null at \'timeToLiveSpecification.attributeName\' failed to satisfy constraint: ' +
+        'Member must not be null',
+        'Value null at \'timeToLiveSpecification.enabled\' failed to satisfy constraint: ' +
+        'Member must not be null',
+      ], done)
+    })
+
+    it('should return ValidationException for empty TimeToLiveSpecification.AttributeName', function(done) {
+      assertValidation({TableName: 'abc',
+        TimeToLiveSpecification: {AttributeName: "", Enabled: true}},
+        'TimeToLiveSpecification.AttributeName must be non empty', done)
+    })
+
+    it('should return ResourceNotFoundException if table does not exist', function(done) {
+      var name = helpers.randomString()
+      assertNotFound({TableName: name,
+        TimeToLiveSpecification: {AttributeName: "id", Enabled: true}},
+        'Requested resource not found: Table: ' + name + ' not found', done)
+    })
+
+    it('should return ValidationException for false TimeToLiveSpecification.Enabled when already disabled', function(done) {
+      assertValidation({TableName: helpers.testHashTable,
+        TimeToLiveSpecification: {AttributeName: "a", Enabled: false}},
+        'TimeToLive is already disabled', done)
+    })
+
+    it('should return ValidationException for true TimeToLiveSpecification.Enabled when already enabled', function(done) {
+      request(opts({TableName: helpers.testHashTable, TimeToLiveSpecification: {AttributeName: "a", Enabled: true}}), function(err, res) {
+        if (err) return done(err)
+        res.statusCode.should.equal(200)
+
+        assertValidation({TableName: helpers.testHashTable,
+          TimeToLiveSpecification: {AttributeName: "a", Enabled: true}},
+          'TimeToLive is already enabled', function(err){
+            if (err) return done(err)
+            // teardown
+            request(opts({TableName: helpers.testHashTable, TimeToLiveSpecification: {AttributeName: "a", Enabled: false}}), function(err, res) {
+              if (err) return done(err)
+              res.statusCode.should.equal(200)
+              done()
+            })
+          })
+      })
+    })
+  })
+
+  describe('functionality', function() {
+    it('should enable when disabled', function(done) {
+      request(opts({TableName: helpers.testHashTable, TimeToLiveSpecification: {AttributeName: "a", Enabled: true}}), function(err, res) {
+        if (err) return done(err)
+        res.statusCode.should.equal(200)
+        res.body.should.eql({TimeToLiveSpecification: {AttributeName: "a", Enabled: true}})
+
+        request(helpers.opts('DescribeTimeToLive', {TableName: helpers.testHashTable}), function(err, res) {
+          if (err) return done(err)
+          res.statusCode.should.equal(200)
+          res.body.should.eql({TimeToLiveDescription: {TimeToLiveStatus: "ENABLED", AttributeName: "a"}})
+
+          // teardown
+          request(opts({TableName: helpers.testHashTable, TimeToLiveSpecification: {AttributeName: "a", Enabled: false}}), function(err, res) {
+            if (err) return done(err)
+            res.statusCode.should.equal(200)
+            done()
+          })
+        })
+      })
+    })
+
+    it('should disable when enabled', function(done) {
+      request(opts({TableName: helpers.testHashTable, TimeToLiveSpecification: {AttributeName: "a", Enabled: true}}), function(err, res) {
+        if (err) return done(err)
+        res.statusCode.should.equal(200)
+        res.body.should.eql({TimeToLiveSpecification: {AttributeName: "a", Enabled: true}})
+
+        request(opts({TableName: helpers.testHashTable, TimeToLiveSpecification: {AttributeName: "a", Enabled: false}}), function(err, res) {
+          if (err) return done(err)
+          res.statusCode.should.equal(200)
+          res.body.should.eql({TimeToLiveSpecification: {Enabled: false}})
+
+
+          request(helpers.opts('DescribeTimeToLive', {TableName: helpers.testHashTable}), function(err, res) {
+            if (err) return done(err)
+            res.statusCode.should.equal(200)
+            res.body.should.eql({TimeToLiveDescription: {TimeToLiveStatus: "DISABLED"}})
+            done()
+          })
+        })
+      })
+    })
+
+    it('should delete the expired items when TTL is enabled', function(done) {
+      request(opts({TableName: helpers.testHashTable, TimeToLiveSpecification: {AttributeName: "TTL", Enabled: true}}), function(err, res) {
+        if (err) return done(err)
+        res.statusCode.should.equal(200)
+        res.body.should.eql({TimeToLiveSpecification: {AttributeName: "TTL", Enabled: true}})
+
+        var timestampOneSecondLater = Math.round(Date.now() / 1000) + 1;
+        var item = {
+          a: {S: helpers.randomString()},
+          TTL: {N: timestampOneSecondLater.toString()},
+        }
+
+        request(helpers.opts('PutItem', {TableName: helpers.testHashTable, Item: item}), function(err, res) {
+          if (err) return done(err)
+          res.statusCode.should.equal(200)
+
+          setTimeout(function(){
+            request(helpers.opts('GetItem', {TableName: helpers.testHashTable, Key: { a: item.a }}), function(err, res) {
+              if (err) return done(err)
+              res.statusCode.should.equal(200)
+              // Item should be deleted
+              res.body.should.eql({})
+
+              // teardown
+              request(opts({TableName: helpers.testHashTable, TimeToLiveSpecification: {AttributeName: "TTL", Enabled: false}}), function(err, res) {
+                if (err) return done(err)
+                res.statusCode.should.equal(200)
+                done()
+              })
+            })
+          }, 3000)
+        })
+      })
+    })
+  })
+})

--- a/test/updateTimeToLive.js
+++ b/test/updateTimeToLive.js
@@ -1,66 +1,66 @@
 var helpers = require('./helpers')
 
 var target = 'UpdateTimeToLive',
-    request = helpers.request,
-    opts = helpers.opts.bind(null, target),
-    assertType = helpers.assertType.bind(null, target),
-    assertValidation = helpers.assertValidation.bind(null, target),
-    assertNotFound = helpers.assertNotFound.bind(null, target)
+  request = helpers.request,
+  opts = helpers.opts.bind(null, target),
+  assertType = helpers.assertType.bind(null, target),
+  assertValidation = helpers.assertValidation.bind(null, target),
+  assertNotFound = helpers.assertNotFound.bind(null, target)
 
-describe('updateTimeToLive', function() {
+describe('updateTimeToLive', function () {
 
-  describe('serializations', function() {
+  describe('serializations', function () {
 
-    it('should return SerializationException when TableName is not a string', function(done) {
+    it('should return SerializationException when TableName is not a string', function (done) {
       assertType('TableName', 'String', done)
     })
 
-    it('should return SerializationException when TimeToLiveSpecification is not a struct', function(done) {
+    it('should return SerializationException when TimeToLiveSpecification is not a struct', function (done) {
       assertType('TimeToLiveSpecification', 'FieldStruct<TimeToLiveSpecification>', done)
     })
 
-    it('should return SerializationException when TimeToLiveSpecification.AttributeName is not a string', function(done) {
+    it('should return SerializationException when TimeToLiveSpecification.AttributeName is not a string', function (done) {
       assertType('TimeToLiveSpecification.AttributeName', 'String', done)
     })
 
-    it('should return SerializationException when TimeToLiveSpecification.Enabled is not a boolean', function(done) {
+    it('should return SerializationException when TimeToLiveSpecification.Enabled is not a boolean', function (done) {
       assertType('TimeToLiveSpecification.Enabled', 'Boolean', done)
     })
 
   })
 
-  describe('validations', function() {
+  describe('validations', function () {
 
-    it('should return ValidationException for no TableName', function(done) {
+    it('should return ValidationException for no TableName', function (done) {
       assertValidation({},
         'The parameter \'TableName\' is required but was not present in the request', done)
     })
 
-    it('should return ValidationException for empty TableName', function(done) {
-      assertValidation({TableName: ''},
+    it('should return ValidationException for empty TableName', function (done) {
+      assertValidation({ TableName: '' },
         'TableName must be at least 3 characters long and at most 255 characters long', done)
     })
 
-    it('should return ValidationException for short TableName', function(done) {
-      assertValidation({TableName: 'a;'},
+    it('should return ValidationException for short TableName', function (done) {
+      assertValidation({ TableName: 'a;' },
         'TableName must be at least 3 characters long and at most 255 characters long', done)
     })
 
-    it('should return ValidationException for long TableName', function(done) {
+    it('should return ValidationException for long TableName', function (done) {
       var name = new Array(256 + 1).join('a')
-      assertValidation({TableName: name},
+      assertValidation({ TableName: name },
         'TableName must be at least 3 characters long and at most 255 characters long', done)
     })
 
-    it('should return ValidationException for invalid chars', function(done) {
-      assertValidation({TableName: 'abc;'},
+    it('should return ValidationException for invalid chars', function (done) {
+      assertValidation({ TableName: 'abc;' },
         '1 validation error detected: ' +
         'Value \'abc;\' at \'tableName\' failed to satisfy constraint: ' +
         'Member must satisfy regular expression pattern: [a-zA-Z0-9_.-]+', done)
     })
 
-    it('should return ValidationException for empty TimeToLiveSpecification', function(done) {
-      assertValidation({TableName: 'abc', TimeToLiveSpecification: {}}, [
+    it('should return ValidationException for empty TimeToLiveSpecification', function (done) {
+      assertValidation({ TableName: 'abc', TimeToLiveSpecification: {} }, [
         'Value null at \'timeToLiveSpecification.enabled\' failed to satisfy constraint: ' +
         'Member must not be null',
         'Value null at \'timeToLiveSpecification.attributeName\' failed to satisfy constraint: ' +
@@ -68,8 +68,8 @@ describe('updateTimeToLive', function() {
       ], done)
     })
 
-    it('should return ValidationException for null members in TimeToLiveSpecification', function(done) {
-      assertValidation({TableName: 'abc', TimeToLiveSpecification: {AttributeName: null, Enabled: null}}, [
+    it('should return ValidationException for null members in TimeToLiveSpecification', function (done) {
+      assertValidation({ TableName: 'abc', TimeToLiveSpecification: { AttributeName: null, Enabled: null } }, [
         'Value null at \'timeToLiveSpecification.attributeName\' failed to satisfy constraint: ' +
         'Member must not be null',
         'Value null at \'timeToLiveSpecification.enabled\' failed to satisfy constraint: ' +
@@ -77,59 +77,59 @@ describe('updateTimeToLive', function() {
       ], done)
     })
 
-    it('should return ValidationException for empty TimeToLiveSpecification.AttributeName', function(done) {
-      assertValidation({TableName: 'abc',
-        TimeToLiveSpecification: {AttributeName: "", Enabled: true}},
-        'TimeToLiveSpecification.AttributeName must be non empty', done)
+    it('should return ValidationException for empty TimeToLiveSpecification.AttributeName', function (done) {
+      assertValidation({ TableName: 'abc',
+        TimeToLiveSpecification: { AttributeName: '', Enabled: true } },
+      'TimeToLiveSpecification.AttributeName must be non empty', done)
     })
 
-    it('should return ResourceNotFoundException if table does not exist', function(done) {
+    it('should return ResourceNotFoundException if table does not exist', function (done) {
       var name = helpers.randomString()
-      assertNotFound({TableName: name,
-        TimeToLiveSpecification: {AttributeName: "id", Enabled: true}},
-        'Requested resource not found: Table: ' + name + ' not found', done)
+      assertNotFound({ TableName: name,
+        TimeToLiveSpecification: { AttributeName: 'id', Enabled: true } },
+      'Requested resource not found: Table: ' + name + ' not found', done)
     })
 
-    it('should return ValidationException for false TimeToLiveSpecification.Enabled when already disabled', function(done) {
-      assertValidation({TableName: helpers.testHashTable,
-        TimeToLiveSpecification: {AttributeName: "a", Enabled: false}},
-        'TimeToLive is already disabled', done)
+    it('should return ValidationException for false TimeToLiveSpecification.Enabled when already disabled', function (done) {
+      assertValidation({ TableName: helpers.testHashTable,
+        TimeToLiveSpecification: { AttributeName: 'a', Enabled: false } },
+      'TimeToLive is already disabled', done)
     })
 
-    it('should return ValidationException for true TimeToLiveSpecification.Enabled when already enabled', function(done) {
-      request(opts({TableName: helpers.testHashTable, TimeToLiveSpecification: {AttributeName: "a", Enabled: true}}), function(err, res) {
+    it('should return ValidationException for true TimeToLiveSpecification.Enabled when already enabled', function (done) {
+      request(opts({ TableName: helpers.testHashTable, TimeToLiveSpecification: { AttributeName: 'a', Enabled: true } }), function (err, res) {
         if (err) return done(err)
         res.statusCode.should.equal(200)
 
-        assertValidation({TableName: helpers.testHashTable,
-          TimeToLiveSpecification: {AttributeName: "a", Enabled: true}},
-          'TimeToLive is already enabled', function(err){
+        assertValidation({ TableName: helpers.testHashTable,
+          TimeToLiveSpecification: { AttributeName: 'a', Enabled: true } },
+        'TimeToLive is already enabled', function (err){
+          if (err) return done(err)
+          // teardown
+          request(opts({ TableName: helpers.testHashTable, TimeToLiveSpecification: { AttributeName: 'a', Enabled: false } }), function (err, res) {
             if (err) return done(err)
-            // teardown
-            request(opts({TableName: helpers.testHashTable, TimeToLiveSpecification: {AttributeName: "a", Enabled: false}}), function(err, res) {
-              if (err) return done(err)
-              res.statusCode.should.equal(200)
-              done()
-            })
+            res.statusCode.should.equal(200)
+            done()
           })
+        })
       })
     })
   })
 
-  describe('functionality', function() {
-    it('should enable when disabled', function(done) {
-      request(opts({TableName: helpers.testHashTable, TimeToLiveSpecification: {AttributeName: "a", Enabled: true}}), function(err, res) {
+  describe('functionality', function () {
+    it('should enable when disabled', function (done) {
+      request(opts({ TableName: helpers.testHashTable, TimeToLiveSpecification: { AttributeName: 'a', Enabled: true } }), function (err, res) {
         if (err) return done(err)
         res.statusCode.should.equal(200)
-        res.body.should.eql({TimeToLiveSpecification: {AttributeName: "a", Enabled: true}})
+        res.body.should.eql({ TimeToLiveSpecification: { AttributeName: 'a', Enabled: true } })
 
-        request(helpers.opts('DescribeTimeToLive', {TableName: helpers.testHashTable}), function(err, res) {
+        request(helpers.opts('DescribeTimeToLive', { TableName: helpers.testHashTable }), function (err, res) {
           if (err) return done(err)
           res.statusCode.should.equal(200)
-          res.body.should.eql({TimeToLiveDescription: {TimeToLiveStatus: "ENABLED", AttributeName: "a"}})
+          res.body.should.eql({ TimeToLiveDescription: { TimeToLiveStatus: 'ENABLED', AttributeName: 'a' } })
 
           // teardown
-          request(opts({TableName: helpers.testHashTable, TimeToLiveSpecification: {AttributeName: "a", Enabled: false}}), function(err, res) {
+          request(opts({ TableName: helpers.testHashTable, TimeToLiveSpecification: { AttributeName: 'a', Enabled: false } }), function (err, res) {
             if (err) return done(err)
             res.statusCode.should.equal(200)
             done()
@@ -138,102 +138,102 @@ describe('updateTimeToLive', function() {
       })
     })
 
-    it('should disable when enabled', function(done) {
-      request(opts({TableName: helpers.testHashTable, TimeToLiveSpecification: {AttributeName: "a", Enabled: true}}), function(err, res) {
+    it('should disable when enabled', function (done) {
+      request(opts({ TableName: helpers.testHashTable, TimeToLiveSpecification: { AttributeName: 'a', Enabled: true } }), function (err, res) {
         if (err) return done(err)
         res.statusCode.should.equal(200)
-        res.body.should.eql({TimeToLiveSpecification: {AttributeName: "a", Enabled: true}})
+        res.body.should.eql({ TimeToLiveSpecification: { AttributeName: 'a', Enabled: true } })
 
-        request(opts({TableName: helpers.testHashTable, TimeToLiveSpecification: {AttributeName: "a", Enabled: false}}), function(err, res) {
+        request(opts({ TableName: helpers.testHashTable, TimeToLiveSpecification: { AttributeName: 'a', Enabled: false } }), function (err, res) {
           if (err) return done(err)
           res.statusCode.should.equal(200)
-          res.body.should.eql({TimeToLiveSpecification: {Enabled: false}})
+          res.body.should.eql({ TimeToLiveSpecification: { Enabled: false } })
 
 
-          request(helpers.opts('DescribeTimeToLive', {TableName: helpers.testHashTable}), function(err, res) {
+          request(helpers.opts('DescribeTimeToLive', { TableName: helpers.testHashTable }), function (err, res) {
             if (err) return done(err)
             res.statusCode.should.equal(200)
-            res.body.should.eql({TimeToLiveDescription: {TimeToLiveStatus: "DISABLED"}})
+            res.body.should.eql({ TimeToLiveDescription: { TimeToLiveStatus: 'DISABLED' } })
             done()
           })
         })
       })
     })
 
-    it('should delete the expired items from Tables and Indices when TTL is enabled', function(done) {
-      request(opts({TableName: helpers.testRangeTable, TimeToLiveSpecification: {AttributeName: "TTL", Enabled: true}}), function(err, res) {
+    it('should delete the expired items from Tables and Indices when TTL is enabled', function (done) {
+      request(opts({ TableName: helpers.testRangeTable, TimeToLiveSpecification: { AttributeName: 'TTL', Enabled: true } }), function (err, res) {
         if (err) return done(err)
         res.statusCode.should.equal(200)
-        res.body.should.eql({TimeToLiveSpecification: {AttributeName: "TTL", Enabled: true}})
+        res.body.should.eql({ TimeToLiveSpecification: { AttributeName: 'TTL', Enabled: true } })
 
-        var timestampNow = Math.round(Date.now() / 1000);
+        var timestampNow = Math.round(Date.now() / 1000)
         var sharedPk = helpers.randomString()
         var sharedGsiPk = helpers.randomString()
         var expiredItem = {
-          a: {S: sharedPk},
-          b: {S: helpers.randomString()},
-          c: {S: sharedGsiPk},
-          d: {S: helpers.randomString()},
-          TTL: {N: (timestampNow + 1).toString()},
+          a: { S: sharedPk },
+          b: { S: helpers.randomString() },
+          c: { S: sharedGsiPk },
+          d: { S: helpers.randomString() },
+          TTL: { N: (timestampNow + 1).toString() },
         }
         var livingItem = {
-          a: {S: sharedPk},
-          b: {S: helpers.randomString()},
-          c: {S: sharedGsiPk},
-          d: {S: helpers.randomString()},
-          TTL: {N: (timestampNow + 1000000).toString()},
+          a: { S: sharedPk },
+          b: { S: helpers.randomString() },
+          c: { S: sharedGsiPk },
+          d: { S: helpers.randomString() },
+          TTL: { N: (timestampNow + 1000000).toString() },
         }
         var batchWriteItemInput = {
           RequestItems: {},
         }
         batchWriteItemInput.RequestItems[helpers.testRangeTable] = [
-          { PutRequest: { Item: expiredItem }},
-          { PutRequest: { Item: livingItem  }},
+          { PutRequest: { Item: expiredItem } },
+          { PutRequest: { Item: livingItem  } },
         ]
-        request(helpers.opts('BatchWriteItem', batchWriteItemInput), function(err, res) {
+        request(helpers.opts('BatchWriteItem', batchWriteItemInput), function (err, res) {
           if (err) return done(err)
           res.statusCode.should.equal(200)
 
-          setTimeout(function(){
+          setTimeout(function (){
             request(helpers.opts('Query', {
               TableName: helpers.testRangeTable,
-              KeyConditionExpression: "a = :a",
+              KeyConditionExpression: 'a = :a',
               ExpressionAttributeValues: {
-                ":a": expiredItem.a,
+                ':a': expiredItem.a,
               },
-            }), function(err, res) {
+            }), function (err, res) {
               if (err) return done(err)
               res.statusCode.should.equal(200)
-              res.body.Items.should.eql([livingItem], 'Expired item should be deleted from table')
+              res.body.Items.should.eql([ livingItem ], 'Expired item should be deleted from table')
 
               request(helpers.opts('Query', {
                 TableName: helpers.testRangeTable,
                 IndexName: 'index1',
-                KeyConditionExpression: "a = :a",
+                KeyConditionExpression: 'a = :a',
                 ExpressionAttributeValues: {
-                  ":a": expiredItem.a,
+                  ':a': expiredItem.a,
                 },
-              }), function(err, res) {
+              }), function (err, res) {
                 if (err) return done(err)
                 res.statusCode.should.equal(200)
-                res.body.Items.should.eql([livingItem], "Expired Item should be deleted from LSI")
+                res.body.Items.should.eql([ livingItem ], 'Expired Item should be deleted from LSI')
 
                 request(helpers.opts('Query', {
                   TableName: helpers.testRangeTable,
                   IndexName: 'index3',
-                  KeyConditionExpression: "c = :c",
+                  KeyConditionExpression: 'c = :c',
                   ExpressionAttributeValues: {
-                    ":c": expiredItem.c,
+                    ':c': expiredItem.c,
                   },
-                }), function(err, res) {
+                }), function (err, res) {
                   if (err) return done(err)
                   res.statusCode.should.equal(200)
-                  res.body.Items.should.eql([livingItem], "Expired Item should be deleted from GSI")
+                  res.body.Items.should.eql([ livingItem ], 'Expired Item should be deleted from GSI')
 
                   // teardown
                   request(opts({
                     TableName: helpers.testRangeTable,
-                    TimeToLiveSpecification: {AttributeName: "TTL", Enabled: false}
+                    TimeToLiveSpecification: { AttributeName: 'TTL', Enabled: false }
                   }), function (err, res) {
                     if (err) return done(err)
                     res.statusCode.should.equal(200)

--- a/validations/updateTimeToLive.js
+++ b/validations/updateTimeToLive.js
@@ -1,0 +1,30 @@
+exports.types = {
+  TableName: {
+    type: 'String',
+    required: true,
+    tableName: true,
+    regex: '[a-zA-Z0-9_.-]+',
+  },
+  TimeToLiveSpecification: {
+    type: 'FieldStruct<TimeToLiveSpecification>',
+    children: {
+      AttributeName: {
+        type: 'String',
+        required: true,
+        notNull: true,
+      },
+      Enabled: {
+        type: 'Boolean',
+        required: true,
+        notNull: true,
+      },
+    },
+  },
+}
+
+
+exports.custom = function(data) {
+  if (data.TimeToLiveSpecification.AttributeName === '') {
+    return 'TimeToLiveSpecification.AttributeName must be non empty';
+  }
+}

--- a/validations/updateTimeToLive.js
+++ b/validations/updateTimeToLive.js
@@ -23,8 +23,8 @@ exports.types = {
 }
 
 
-exports.custom = function(data) {
+exports.custom = function (data) {
   if (data.TimeToLiveSpecification.AttributeName === '') {
-    return 'TimeToLiveSpecification.AttributeName must be non empty';
+    return 'TimeToLiveSpecification.AttributeName must be non empty'
   }
 }


### PR DESCRIPTION
Closes #103

- Run background "scanner" job: using `setInterval` to support legacy Node.js not having Worker threads
- The job scans items with the TTL attribute. Then, it delete the expired items.


TODO
- [x] Enable TTL Scanner background job only if TTL is enabled
- [x] Configurable scanning job interval 
- [x] Delete items from GSI/LSI too
- [x] Testing with a table created w/ TTL, not via `UpdateTimeToLive`

