### PR TITLE
Migrate to Github Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [6, 8, 10, 12, 14, 16]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-  - "6"
-  - "8"
-  - "10"
-  - "12"


### PR DESCRIPTION
This PR migrates CI from Travis to GitHub Actions.

GH Actions is free for public repository.
https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions

The result of run can be found on my fork.
https://github.com/exoego/dynalite/pull/1
