### PR TITLE
Add failing test for 'in (false)' condition expr

### DIFF
--- a/test/updateItem.js
+++ b/test/updateItem.js
@@ -1450,6 +1450,11 @@ describe('updateItem', function() {
         UpdateExpression: 'SET #b = :b',
         ExpressionAttributeNames: {'#a': 'active', '#b': 'active'},
         ExpressionAttributeValues: {':a': {BOOL: false}, ':b': {BOOL: true}},
+      }, {
+        ConditionExpression: '#a IN (:a)',
+        UpdateExpression: 'SET #a = :b',
+        ExpressionAttributeNames: {'#a': 'active'},
+        ExpressionAttributeValues: {':a': {BOOL: false}, ':b': {BOOL: true}},
       }], function(updateOpts, cb) {
         var item = {a: {S: helpers.randomString()}, active: {BOOL: false}}
         request(helpers.opts('PutItem', {TableName: helpers.testHashTable, Item: item}), function(err, res) {


### PR DESCRIPTION
dynalite incorrectly rejects condition expressions when using `IN` with `false`.

For example, if we have an item `{key: {S: "key"}, val: {BOOL: false}}` and do an update with a condition expression `{ConditionExpression: "#v IN (:f)", ExpressionAttributeNames: {"#v": "val"}, ExpressionAttributeValues: {":f": {BOOL: false}}` it will fail with conditional check failed, even though it should match.

I tried to fix it myself but unfortunately my JS skills proved to be insufficient, but I did manage to write a test that illustrates the issue, so hopefully someone else can write the actual fix for it. 